### PR TITLE
Init $pagination_html earlier to avoid generating a notice

### DIFF
--- a/admin/class-custom-permalinks-admin.php
+++ b/admin/class-custom-permalinks-admin.php
@@ -235,6 +235,7 @@ class Custom_Permalinks_Admin {
 		$posts      = 0;
 		$table      = get_option( 'custom_permalink_table' );
 		$count_tags = count( $table );
+		$pagination_html = '';
 		if ( isset( $table ) && is_array( $table ) && $count_tags > 0 ) {
 
 			$filtered = array();
@@ -250,7 +251,6 @@ class Custom_Permalinks_Admin {
 
 			$html .= '<h2 class="screen-reader-text">Custom Permalink navigation</h2>';
 
-			$pagination_html = '';
 			$total_pages = ceil( $count_tags / 20 );
 			if ( isset( $_GET['paged'] ) && is_numeric( $_GET['paged'] ) && $_GET['paged'] > 0) {
 				$pagination_html = $this->custom_permalinks_pager( $count_tags, $_GET['paged'], $total_pages);


### PR DESCRIPTION
In some cases $pagination_html isn't defined on line 310. This fixes that.