### PR TITLE
Update class-custom-permalinks-frontend.php

### DIFF
--- a/frontend/class-custom-permalinks-frontend.php
+++ b/frontend/class-custom-permalinks-frontend.php
@@ -193,6 +193,7 @@ class Custom_Permalinks_Frontend {
 				$old_query_string = $_SERVER['QUERY_STRING'];
 			}
 			$_SERVER['REQUEST_URI']  = '/' . ltrim( $original_url, '/' );
+			$_SERVER['PATH_INFO']  = '/' . ltrim( $original_url, '/' );
 			$_SERVER['QUERY_STRING'] = ( ( $pos = strpos( $original_url, '?' ) ) !== false ? substr( $original_url, $pos + 1 ) : '' );
 			parse_str( $_SERVER['QUERY_STRING'], $query_array );
 			$old_values = array();


### PR DESCRIPTION
For some reason our setup needed to have the original path info defined before WP->parse_request was able to find the original post. I've emailed you about this issue before.