### PR TITLE
Public statuses first

### DIFF
--- a/frontend/class-custom-permalinks-frontend.php
+++ b/frontend/class-custom-permalinks-frontend.php
@@ -234,6 +234,10 @@ class Custom_Permalinks_Frontend {
   public function make_redirect() {
     global $wpdb;
 
+    if ( is_preview() ) {
+      return;
+    }
+
     $custom_permalink   = '';
     $original_permalink = '';
 
@@ -341,6 +345,11 @@ class Custom_Permalinks_Frontend {
    * @return string
    */
   public function custom_permalinks_post_link( $permalink, $post ) {
+    parse_str( parse_url( $permalink, PHP_URL_QUERY ), $query_string );
+    if ( ! empty( $query_string['p'] ) ) {
+      return $permalink;
+    }
+
     $custom_permalink = get_post_meta( $post->ID, 'custom_permalink', true );
     if ( $custom_permalink ) {
       $post_type = isset( $post->post_type ) ? $post->post_type : 'post';
@@ -361,6 +370,11 @@ class Custom_Permalinks_Frontend {
    * @return string
    */
   public function custom_permalinks_page_link( $permalink, $page ) {
+    parse_str( parse_url( $permalink, PHP_URL_QUERY ), $query_string );
+    if ( ! empty( $query_string['page_id'] ) ) {
+      return $permalink;
+    }
+
     $custom_permalink = get_post_meta( $page, 'custom_permalink', true );
     if ( $custom_permalink ) {
       $language_code = apply_filters( 'wpml_element_language_code', null, array( 'element_id' => $page, 'element_type' => 'page' ) );

--- a/frontend/class-custom-permalinks-frontend.php
+++ b/frontend/class-custom-permalinks-frontend.php
@@ -527,11 +527,11 @@ class Custom_Permalinks_Frontend {
    * @return string
    */
   public function ordered_statuses() {
-  global $wp_post_statuses;
+    global $wp_post_statuses;
 
-  $post_statuses = new WP_List_Util( $wp_post_statuses );
-  $post_statuses->sort( 'public', 'DESC' );
+    $post_statuses = new WP_List_Util( $wp_post_statuses );
+    $post_statuses->sort( 'public', 'DESC' );
 
-  return "'" . implode( "','", $post_statuses->pluck( 'name' ) ) . "'";
+    return "'" . implode( "','", $post_statuses->pluck( 'name' ) ) . "'";
   }
 }

--- a/frontend/class-custom-permalinks-frontend.php
+++ b/frontend/class-custom-permalinks-frontend.php
@@ -88,8 +88,8 @@ class Custom_Permalinks_Frontend {
             " WHERE pm.meta_key = 'custom_permalink' " .
             " AND (pm.meta_value = '%s' OR pm.meta_value = '%s') " .
             " AND p.post_status != 'trash' AND p.post_type != 'nav_menu_item' " .
-            " ORDER BY FIELD(post_status,'publish','private','pending','draft','auto-draft','inherit')," .
-            " FIELD(post_type,'post','page') LIMIT 1", $request_noslash, $request_noslash . "/" );
+            " ORDER BY FIELD(post_status,%s)," .
+            " FIELD(post_type,'post','page') LIMIT 1", $request_noslash, $request_noslash . "/", $this->ordered_statuses() );
 
     $posts = $wpdb->get_results( $sql );
 
@@ -102,9 +102,9 @@ class Custom_Permalinks_Frontend {
               "   LOWER(meta_value) = LEFT(LOWER('%s'), LENGTH(meta_value)) ) " .
               "  AND post_status != 'trash' AND post_type != 'nav_menu_item'" .
               " ORDER BY LENGTH(meta_value) DESC, " .
-              " FIELD(post_status,'publish','private','pending','draft','auto-draft','inherit')," .
+              " FIELD(post_status,%s)," .
               " FIELD(post_type,'post','page'), p.ID ASC LIMIT 1",
-              $request_noslash, $request_noslash . "/" );
+              $request_noslash, $request_noslash . "/", $this->ordered_statuses() );
 
       $posts = $wpdb->get_results( $sql );
     }
@@ -260,9 +260,8 @@ class Custom_Permalinks_Frontend {
             " WHERE pm.meta_key = 'custom_permalink' " .
             " AND (pm.meta_value = '%s' OR pm.meta_value = '%s') " .
             " AND p.post_status != 'trash' AND p.post_type != 'nav_menu_item' " .
-            " ORDER BY FIELD(post_status,'publish','private','draft','auto-draft','inherit')," .
-            " FIELD(post_type,'post','page') LIMIT 1", $request_noslash, $request_noslash . "/" );
-
+            " ORDER BY FIELD(post_status,%s)," .
+            " FIELD(post_type,'post','page') LIMIT 1", $request_noslash, $request_noslash . "/", $this->ordered_statuses() );
     $posts = $wpdb->get_results( $sql );
 
     $remove_like_query = apply_filters( 'cp_remove_like_query', '__true' );
@@ -274,9 +273,9 @@ class Custom_Permalinks_Frontend {
               "   LOWER(meta_value) = LEFT(LOWER('%s'), LENGTH(meta_value)) ) " .
               "  AND post_status != 'trash' AND post_type != 'nav_menu_item'" .
               " ORDER BY LENGTH(meta_value) DESC, " .
-              " FIELD(post_status,'publish','private','draft','auto-draft','inherit')," .
+              " FIELD(post_status,%s)," .
               " FIELD(post_type,'post','page'), p.ID ASC LIMIT 1",
-              $request_noslash, $request_noslash . "/" );
+              $request_noslash, $request_noslash . "/", $this->ordered_statuses() );
 
       $posts = $wpdb->get_results( $sql );
     }
@@ -519,5 +518,20 @@ class Custom_Permalinks_Frontend {
       }
     }
     return false;
+  }
+
+  /**
+   * Return a comma-separated list of names of all registered post statuses with public statuses ordered first.
+   *
+   * @access public
+   * @return string
+   */
+  public function ordered_statuses() {
+  global $wp_post_statuses;
+
+  $post_statuses = new WP_List_Util( $wp_post_statuses );
+  $post_statuses->sort( 'public', 'DESC' );
+
+  return "'" . implode( "','", $post_statuses->pluck( 'name' ) ) . "'";
   }
 }


### PR DESCRIPTION
Another take on fixing an issue when using Oasis Workflows Pro and workflow revisions show up on front end before being published instead of the published original.

This pulls all registered post statuses, orders them "public" first and generates a string to use in the SQL queries that need to order by post status.