### PR TITLE
Add support for Polylang "hide_default" setting.

### DIFF
--- a/frontend/class-custom-permalinks-frontend.php
+++ b/frontend/class-custom-permalinks-frontend.php
@@ -88,7 +88,7 @@ class Custom_Permalinks_Frontend {
             " WHERE pm.meta_key = 'custom_permalink' " .
             " AND (pm.meta_value = '%s' OR pm.meta_value = '%s') " .
             " AND p.post_status != 'trash' AND p.post_type != 'nav_menu_item' " .
-            " ORDER BY FIELD(post_status,'publish','private','pending','draft','auto-draft','inherit')," .
+            " ORDER BY FIELD(post_status,'publish','private','draft','auto-draft','inherit')," .
             " FIELD(post_type,'post','page') LIMIT 1", $request_noslash, $request_noslash . "/" );
 
     $posts = $wpdb->get_results( $sql );
@@ -102,7 +102,7 @@ class Custom_Permalinks_Frontend {
               "   LOWER(meta_value) = LEFT(LOWER('%s'), LENGTH(meta_value)) ) " .
               "  AND post_status != 'trash' AND post_type != 'nav_menu_item'" .
               " ORDER BY LENGTH(meta_value) DESC, " .
-              " FIELD(post_status,'publish','private','pending','draft','auto-draft','inherit')," .
+              " FIELD(post_status,'publish','private','draft','auto-draft','inherit')," .
               " FIELD(post_type,'post','page'), p.ID ASC LIMIT 1",
               $request_noslash, $request_noslash . "/" );
 


### PR DESCRIPTION
I have added a "Topic" over on wordpress.org for this here: https://wordpress.org/support/topic/issue-with-polylang-setting-hide-default-language/.  Afterwards I thought you might a Github repo and might be better to adda Pull Request for this.
[class-custom-permalink-form.zip](https://github.com/yasglobal/custom-permalinks/files/3105022/class-custom-permalink-form.zip)

