### PR TITLE
Fix infinite redirect loop with percent-encoded special characters

### DIFF
--- a/includes/class-custom-permalinks-frontend.php
+++ b/includes/class-custom-permalinks-frontend.php
@@ -65,7 +65,7 @@ class Custom_Permalinks_Frontend {
 
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 			$this->request_uri = sanitize_url(
-				wp_unslash( $_SERVER['REQUEST_URI'] )
+				urldecode( wp_unslash( $_SERVER['REQUEST_URI'] ) )
 			);
 		}
 
@@ -370,7 +370,7 @@ class Custom_Permalinks_Frontend {
 			&& $_SERVER['REQUEST_URI'] !== $this->request_uri
 		) {
 			$this->request_uri = sanitize_url(
-				wp_unslash( $_SERVER['REQUEST_URI'] )
+				urldecode( wp_unslash( $_SERVER['REQUEST_URI'] ) )
 			);
 		}
 
@@ -732,7 +732,7 @@ class Custom_Permalinks_Frontend {
 			&& $_SERVER['REQUEST_URI'] !== $this->request_uri
 		) {
 			$this->request_uri = sanitize_url(
-				wp_unslash( $_SERVER['REQUEST_URI'] )
+				urldecode( wp_unslash( $_SERVER['REQUEST_URI'] ) )
 			);
 		}
 


### PR DESCRIPTION
Bug Description

  Fixes an infinite redirect loop that occurs when URLs contain percent-encoded special characters (such as UTF-8 encoded ligatures or other multibyte characters).

  The issue was caused by `$_SERVER['REQUEST_URI']` not being URL-decoded before being compared with custom permalinks stored in the database.

  Steps to Reproduce

  1. Create a post with a custom permalink containing special characters, e.g., a ligature "ﬂ" (U+FB02):
  `post/study-finds-that-gold-may-hold-the-secret-to-treating-inflammatory-bowel-disease/`
  1. (where "inflammatory" contains the "ﬂ" ligature)
  2. Access the URL with percent-encoding (as browsers naturally send it):
  `https://example.com/post/study-finds-that-gold-may-hold-the-secret-to-treating-in%EF%AC%82ammatory-bowel-disease/`
  3. Observe: Browser enters infinite redirect loop (ERR_TOO_MANY_REDIRECTS)

  Root Cause

  File: `includes/class-custom-permalinks-frontend.php`

  Lines 66-69, 372-374, 734-736: The `$this->request_uri `was sanitized but never URL-decoded:

```
  $this->request_uri = sanitize_url(
      wp_unslash( $_SERVER['REQUEST_URI'] )
  );
```

  Later, this encoded string was compared with the decoded custom permalink from the database, causing a mismatch that triggered redirects:

  1. `$_SERVER['REQUEST_URI']` contains `...in%EF%AC%82ammatory...` (percent-encoded)
  2. Database stores ...inﬂammatory... (decoded UTF-8 character)
  3. String comparison fails: `$request !== $custom_permalink`
  4. Plugin redirects to what it thinks is the "correct" URL
  5. Browser sends the same percent-encoded URL again
  6. Loop repeats infinitely

  Changes Made

  Added urldecode() when storing $this->request_uri at three locations:
  - Line 68: init() method
  - Line 373: parse_request() method
  - Line 735: make_redirect() method

```
  $this->request_uri = sanitize_url(
      urldecode( wp_unslash( $_SERVER['REQUEST_URI'] ) )
  );
```

  This ensures all internal URL comparisons work with decoded strings, matching what's stored in the database and preventing false mismatches that trigger unnecessary redirects.

  Testing

  Tested with URLs containing:
  - UTF-8 ligatures (ﬂ, ﬁ, etc.)
  - Non-ASCII international characters
  - Other special characters that get percent-encoded by browsers

  All URLs now work correctly without infinite redirects.

  Affected URLs

  This fix particularly benefits:
  - Non-ASCII URLs (international characters)
  - URLs with ligatures (ﬂ, ﬁ, etc.)
  - URLs with special characters that get percent-encoded by browsers
