### PR TITLE
Adds conditional for post instance of WP_Post

### DIFF
--- a/includes/class-custom-permalinks-form.php
+++ b/includes/class-custom-permalinks-form.php
@@ -86,7 +86,7 @@ class Custom_Permalinks_Form {
 	 * return bool Whether Custom Permalink is customizable or not.
 	 */
 	private function is_permalink_customizable( $post ) {
-		if ( ! is_object( $post ) ) {
+		if ( ! is_object( $post ) || (!$post instanceof('\WP_Post')) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Adds a type check for `WP_Post` in the `is_permalink_customizable` method of `Custom_Permalinks_Form`. 

When the object is not an instance of `WP_Post`, the error log is showing PHP notices. 

**A specific example:**
If WooCommerce is installed, and you are viewing an order, the global post object is updated to a `WC_Order` object. If the error log is enabled, notices are shown about directly accessing order meta due to the $post->post_type property reference. 